### PR TITLE
Set wochenteller to None on parsing failure

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ class Parser:
         try:
             wochenteller = self._parse_wochenteller(menuplan)
         except Exception as e:
+            wochenteller = None
             log.warning(f"Could not parse Wochenteller: {e}")
 
         monday_tag = menuplan.find_next_sibling(


### PR DESCRIPTION
Handle exception by setting wochenteller to None.
This fixes the Github Actions run errors.